### PR TITLE
Update serialport version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "ws": "0.8.0",
-    "serialport": "1.7.4"
+    "serialport": "3.1.2"
   },
   "license": "GPL"
 }


### PR DESCRIPTION
Updated the serialport version dependency to latest stable release to support new NodeJs versions. 3.1.2 shouldn't have API changes as far as I can see.